### PR TITLE
add announcement + healthcheck endpoints; fix config

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ npm run build
 npm run start
 ```
 
-The server is then available at http://localhost:8080 by default.
+The server is then available at http://localhost:8081 by default.
 
 When running on Windows, must be run within a Unix-like shell (such as Git Bash)
 

--- a/app/config.ts
+++ b/app/config.ts
@@ -1,7 +1,7 @@
 const nconf = require('nconf');
 const path = require('path');
 
-const CONFIG_PATH = path.join(__dirname, 'config_base.json');
+const CONFIG_PATH = path.join(__dirname, 'config.json');
 
 console.log('Loading config from ' + CONFIG_PATH);
 
@@ -42,7 +42,7 @@ nconf
   ])
   .file({ file: CONFIG_PATH })
   .defaults({
-    PORT: 8080,
+    PORT: 8081,
     ENABLE_PAYMENT: false,
 
     OAUTH2_CLIENT_ID: '',

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -42,6 +42,11 @@ router.get('/healthcheck', limitCors, (req: express.Request, res: express.Respon
 });
 
 router.get('/announcements', limitCors, (req: express.Request, res: express.Response) => {
+  // empty / no announcement: {message: '', link: ''}
+  // res.json({
+  //   message: '',
+  //   link: '',
+  // });
   res.json({
     message: 'The first expansion is now on Kickstarter! Click here to check it out',
     link: 'https://ExpeditionGame.com/kickstarter',

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -37,6 +37,17 @@ const publishLimiter = new RateLimit({
   message: 'Publishing too frequently. Please wait 1 minute and then try again',
 });
 
+router.get('/healthcheck', limitCors, (req: express.Request, res: express.Response) => {
+  res.send(' ');
+});
+
+router.get('/announcements', limitCors, (req: express.Request, res: express.Response) => {
+  res.json({
+    message: 'The first expansion is now on Kickstarter! Click here to check it out',
+    link: 'https://ExpeditionGame.com/kickstarter',
+  });
+});
+
 // Phasing out as of 3/21/17; delete any time after 4/14/17
 // Joi validation: require title, author, email (valid email), feedback, players, difficulty
 // userEmail (valid email), platform, shareUserEmail (default false), version (number)

--- a/config-example.json
+++ b/config-example.json
@@ -4,5 +4,17 @@
   "DATABASE_URL": "",
   "OAUTH2_CLIENT_ID": "",
   "OAUTH2_CLIENT_SECRET": "",
-  "SESSION_SECRET": ""
+  "SESSION_SECRET": "",
+  "GOOGLE_SERVICE_KEY": {
+    "type": "service_account",
+    "project_id": "expedition-quest-ide",
+    "private_key_id": "",
+    "private_key": "",
+    "client_email": "",
+    "client_id": "",
+    "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+    "token_uri": "https://accounts.google.com/o/oauth2/token",
+    "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+    "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/expedition-quest-ide%40appspot.gserviceaccount.com"
+  }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,7 +6,7 @@ const NodeExternals = require('webpack-node-externals');
 const options = require('./webpack.dist.config');
 
 options.plugins.push(new CopyWebpackPlugin([
-      { from: 'app/config_base.json' },
-    ]));
+  { from: 'config.json' },
+]));
 
 module.exports = options

--- a/webpack.dist.config.js
+++ b/webpack.dist.config.js
@@ -3,7 +3,7 @@ const Path = require('path');
 const Webpack = require('webpack');
 const NodeExternals = require('webpack-node-externals');
 
-const PORT = process.env.DOCKER_PORT || 8080;
+const PORT = process.env.DOCKER_PORT || 8081;
 
 const options = {
   cache: true,


### PR DESCRIPTION
Switched to port 8081 since the quest creator UI uses 8080
Moved config to exist in the repo root directory as `config.json` like our other repos, and added missing example of GOOGLE SERVICE KEY