### PR TITLE
Update "owner" search parameter behavior

### DIFF
--- a/app/models/Quests.ts
+++ b/app/models/Quests.ts
@@ -128,15 +128,15 @@ export class Quest {
   // TODO: SearchParams interface
   search(partition: string, userId: string, params: QuestSearchParams): Bluebird<QuestInstance[]> {
     // TODO: Validate search params
-    const where: Sequelize.WhereOptions<QuestAttributes> = {partition, tombstone: null};
+    const where: Sequelize.WhereOptions<QuestAttributes> = {partition, published: {$ne: null}, tombstone: null};
 
     if (params.id) {
       where.id = params.id;
     }
 
     // Require results to be published if we're not querying our own quests
-    if (params.owner !== userId || userId === '') {
-      where.published = {$ne: null};
+    if (params.owner) {
+      where.userid = params.owner;
     }
 
     if (params.players) {


### PR DESCRIPTION
This is a companion to the recent "private publish" PRs, where the behavior of an "owner" search should search for quests specific to that owner. Note that this search parameter is actually completely unused in the app currently, due to changes in search filters that weren't propagated to the API server.

All quests must now be published to be searchable (which may change later if we add a search in the IDE for unpublished quests, but is fine for now).

