### PR TITLE
Update CORS rules

### DIFF
--- a/app/Routes.ts
+++ b/app/Routes.ts
@@ -25,7 +25,7 @@ const limitCors = Cors({
   // - file (for mobile apps)
   // - localhost (for local dev)
   // - *.local (for dev on mobile)
-  origin: /(expedition(game|rpg)\.com$)|(^file:\/\/)|(localhost(:[0-9]+)?$)|(.*\.local$)/i,
+  origin: /(expedition(game|rpg)\.com$)|(^file:\/\/)|(localhost(:[0-9]+)?$)|(.*\.local(:[0-9]+)?$)/i,
   optionsSuccessStatus: 200, // some legacy browsers (IE11, various SmartTVs) choke on 204
 });
 

--- a/app/Routes.ts
+++ b/app/Routes.ts
@@ -20,8 +20,16 @@ Router.use(oauth2.template);
 
 const limitCors = Cors({
   credentials: true,
-  // allows expedition domains, localhost and file (for dev + mobile apps)
-  origin: /(expedition(game|rpg)\.com$)|(localhost(:[0-9]+)?$)|(^file:\/\/)/i,
+  // For prod, allow:
+  // - expedition domains (for web apps)
+  // - file (for mobile apps)
+  //
+  // For dev, allow all prod domains, plus:
+  // - localhost (for local dev)
+  // - *.local (for dev on mobile)
+  origin: (Config.get('NODE_ENV') !== 'dev')
+    ? /(expedition(game|rpg)\.com$)|(^file:\/\/)/i
+    : /(expedition(game|rpg)\.com$)|(^file:\/\/)|(localhost(:[0-9]+)?$)|(.*\.local$)/i,
   optionsSuccessStatus: 200, // some legacy browsers (IE11, various SmartTVs) choke on 204
 });
 

--- a/app/Routes.ts
+++ b/app/Routes.ts
@@ -20,16 +20,12 @@ Router.use(oauth2.template);
 
 const limitCors = Cors({
   credentials: true,
-  // For prod, allow:
+  // Allow:
   // - expedition domains (for web apps)
   // - file (for mobile apps)
-  //
-  // For dev, allow all prod domains, plus:
   // - localhost (for local dev)
   // - *.local (for dev on mobile)
-  origin: (Config.get('NODE_ENV') !== 'dev')
-    ? /(expedition(game|rpg)\.com$)|(^file:\/\/)/i
-    : /(expedition(game|rpg)\.com$)|(^file:\/\/)|(localhost(:[0-9]+)?$)|(.*\.local$)/i,
+  origin: /(expedition(game|rpg)\.com$)|(^file:\/\/)|(localhost(:[0-9]+)?$)|(.*\.local$)/i,
   optionsSuccessStatus: 200, // some legacy browsers (IE11, various SmartTVs) choke on 204
 });
 


### PR DESCRIPTION
This allows *.local hostnames to hit the API, which in turn lets us test locally-hosted mobile web code.